### PR TITLE
Replace deprecated calls to Atom API

### DIFF
--- a/lib/prettify.coffee
+++ b/lib/prettify.coffee
@@ -3,8 +3,8 @@ beautify = require('js-beautify').html
 
 module.exports =
   activate: ->
-    atom.workspaceView.command 'prettify:prettify', '.editor', ->
-      editor = atom.workspaceView.getActivePaneItem()
+    atom.commands.add 'atom-text-editor', 'prettify:prettify': (event) ->
+      editor = @getModel()
       prettify(editor)
 
 prettify = (editor) ->
@@ -12,5 +12,5 @@ prettify = (editor) ->
   sortableRanges.forEach (range) ->
     text = editor.getTextInBufferRange(range)
     text = beautify text,
-      'indent_size': atom.config.get('editor.tabLength')
+      "indent_size": 2
     editor.setTextInBufferRange(range, text)


### PR DESCRIPTION
Usage of WorkspaceView is deprecated in most cases (in fact Atom 0.187.0 currently throws a warning when using this plugin). Therefore we're now using the new simplified API to gain access to the editor content and the list of commands.
